### PR TITLE
feat: Add LM Studio backend + Qwen3 model defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,43 @@
+# =============================================================
+# Turbo Local Coder Agent — LM Studio Configuration
+# Copy this file to .env and fill in your values
+# =============================================================
+
+# ---- Backend Selection ----
+# Options: lmstudio | ollama | llamacpp
+BACKEND=lmstudio
+
+# ---- LM Studio (default backend) ----
+# LM Studio runs its local server at port 1234 by default
+LMSTUDIO_HOST=http://localhost:1234
+
+# ---- Model Selection ----
+# These must match the model identifiers shown in LM Studio's loaded models
+# Planner: use your largest/smartest model for planning
+PLANNER_MODEL=qwen3-8b
+
+# Coder/Executor: fastest model for tool-call execution
+CODER_MODEL=qwen3-4b
+
+# Other available models you can swap in:
+# PLANNER_MODEL=qwen3-8b
+# PLANNER_MODEL=qwen2.5-coder:7b
+# CODER_MODEL=qwen3-2b
+# CODER_MODEL=qwen3-0.8b   # for ultra-fast dry runs
+
+# ---- Execution Settings ----
+MAX_STEPS=25
+REQUEST_TIMEOUT_S=120
+DRY_RUN=0
+
+# ---- Ollama (only needed if BACKEND=ollama) ----
+OLLAMA_LOCAL=http://127.0.0.1:11434
+OLLAMA_API_KEY=
+TURBO_HOST=http://localhost:1234
+
+# ---- llama.cpp (only needed if BACKEND=llamacpp) ----
+LLAMACPP_MODEL_PATH=./models/phi-4-mini-Q4_K_M.gguf
+LLAMACPP_PORT=8080
+LLAMACPP_USE_VULKAN=1
+LLAMACPP_N_GPU_LAYERS=0
+LLAMACPP_CONTEXT_SIZE=4096

--- a/agent/core/backend_manager.py
+++ b/agent/core/backend_manager.py
@@ -1,11 +1,11 @@
-"""Backend Manager - Unified interface for Ollama and llama.cpp backends."""
+"""Backend Manager - Unified interface for Ollama, llama.cpp, and LM Studio backends."""
 from __future__ import annotations
 
 import json
 import logging
 import atexit
 from typing import Any, Iterator, Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import httpx
 
@@ -16,124 +16,212 @@ from .config import Settings
 class ChatResponse:
     """Standardized response from any backend."""
     content: str
-    tool_calls: list[dict] = None
+    tool_calls: Optional[list[dict]] = field(default=None)
     done: bool = False
-    
+
 
 class BaseBackend:
     """Base class for LLM backends with connection pooling."""
-    
+
     def __init__(self, settings: Settings):
         self.settings = settings
         self.logger = logging.getLogger(self.__class__.__name__)
-        
-        # Connection pool for better performance
+
         self._client = httpx.Client(
             timeout=httpx.Timeout(settings.request_timeout_s, connect=10.0),
             limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
             follow_redirects=True
         )
-        
-        # Register cleanup
         atexit.register(self._cleanup)
-    
+
     def _cleanup(self):
-        """Close HTTP client on exit."""
         if hasattr(self, '_client'):
             self._client.close()
-    
-    def chat(self, messages: list[dict], model: str, tools: list[dict] = None, 
+
+    def chat(self, messages: list[dict], model: str, tools: list[dict] = None,
              stream: bool = True) -> Iterator[ChatResponse]:
-        """Send chat request and yield responses."""
         raise NotImplementedError
-    
+
     def is_available(self) -> bool:
-        """Check if backend is available."""
         raise NotImplementedError
-    
+
     def get_models(self) -> list[str]:
-        """List available models."""
         raise NotImplementedError
+
+
+class LMStudioBackend(BaseBackend):
+    """LM Studio backend using its OpenAI-compatible local API (http://localhost:1234/v1)."""
+
+    def chat(self, messages: list[dict], model: str, tools: list[dict] = None,
+             stream: bool = True) -> Iterator[ChatResponse]:
+        """Send chat to LM Studio OpenAI-compatible API."""
+        url = f"{self.settings.lmstudio_host}/v1/chat/completions"
+
+        payload = {
+            "model": model,
+            "messages": messages,
+            "stream": stream,
+            "max_tokens": 2048,
+            "temperature": 0.05,
+            "top_p": 0.85,
+            "frequency_penalty": 0.1,
+            "presence_penalty": 0.1,
+        }
+
+        if tools:
+            payload["tools"] = tools
+
+        self.logger.debug(f"LM Studio {model}: {len(messages)} messages, stream={stream}")
+
+        try:
+            if not stream:
+                resp = self._client.post(url, json=payload)
+                resp.raise_for_status()
+                data = resp.json()
+
+                choices = data.get("choices", [])
+                if choices:
+                    message = choices[0].get("message", {})
+                    yield ChatResponse(
+                        content=message.get("content", "") or "",
+                        tool_calls=message.get("tool_calls"),
+                        done=True
+                    )
+                else:
+                    yield ChatResponse(content="", done=True)
+            else:
+                with self._client.stream("POST", url, json=payload) as resp:
+                    resp.raise_for_status()
+
+                    chunks: list[str] = []
+                    tool_calls = None
+
+                    for line in resp.iter_lines():
+                        if not line or not line.startswith("data: "):
+                            continue
+
+                        data_str = line[6:]  # Remove "data: "
+                        if data_str == "[DONE]":
+                            break
+
+                        try:
+                            data = json.loads(data_str)
+                        except json.JSONDecodeError:
+                            continue
+
+                        choices = data.get("choices", [])
+                        if not choices:
+                            continue
+
+                        delta = choices[0].get("delta", {})
+                        chunk = delta.get("content") or ""
+
+                        if chunk:
+                            chunks.append(chunk)
+                            yield ChatResponse(content=chunk, done=False)
+
+                        if delta.get("tool_calls"):
+                            tool_calls = delta["tool_calls"]
+
+                        if choices[0].get("finish_reason") == "stop":
+                            yield ChatResponse(
+                                content="".join(chunks),
+                                tool_calls=tool_calls,
+                                done=True
+                            )
+                            break
+
+        except httpx.HTTPError as e:
+            self.logger.error(f"LM Studio request failed: {e}")
+            raise
+
+    def is_available(self) -> bool:
+        """Check if LM Studio server is running."""
+        try:
+            resp = self._client.get(f"{self.settings.lmstudio_host}/v1/models", timeout=3)
+            return resp.status_code == 200
+        except Exception as e:
+            self.logger.debug(f"LM Studio unavailable: {e}")
+            return False
+
+    def get_models(self) -> list[str]:
+        """List models loaded in LM Studio."""
+        try:
+            resp = self._client.get(f"{self.settings.lmstudio_host}/v1/models", timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            return [m["id"] for m in data.get("data", [])]
+        except Exception as e:
+            self.logger.error(f"Failed to list LM Studio models: {e}")
+            return []
 
 
 class OllamaBackend(BaseBackend):
     """Ollama backend with optimized parameters."""
-    
+
     def chat(self, messages: list[dict], model: str, tools: list[dict] = None,
              stream: bool = True) -> Iterator[ChatResponse]:
-        """Send chat to Ollama API with optimizations."""
         url = f"{self.settings.local_host}/api/chat"
-        
-        # Highly optimized parameters for speed
+
         payload = {
             "model": model,
             "messages": messages,
             "stream": stream,
             "options": {
-                "num_predict": 2048,      # Max tokens
-                "temperature": 0.05,       # Very low = faster + deterministic
-                "top_p": 0.85,             # Nucleus sampling
-                "top_k": 20,               # Reduced for speed
-                "repeat_penalty": 1.05,    # Light penalty
-                "num_thread": 8,           # Max CPU threads
-                "num_batch": 512,          # Batch size
-                "num_ctx": 4096,           # Context window
+                "num_predict": 2048,
+                "temperature": 0.05,
+                "top_p": 0.85,
+                "top_k": 20,
+                "repeat_penalty": 1.05,
+                "num_thread": 8,
+                "num_batch": 512,
+                "num_ctx": 4096,
                 "stop": ["</tool_call>", "<|end|>", "<|endoftext|>"],
             }
         }
-        
-        # Only add tools if provided
+
         if tools:
             payload["tools"] = tools
-        
+
         self.logger.debug(f"Ollama {model}: {len(messages)} messages, stream={stream}")
-        
+
         try:
             if not stream:
-                # Non-streaming: single response
                 resp = self._client.post(url, json=payload)
                 resp.raise_for_status()
                 data = resp.json()
-                
+
                 msg = data.get("message", {}) or {}
                 content = msg.get("content", "")
                 tool_calls = msg.get("tool_calls")
-                
-                # Log performance
                 self._log_performance(data)
-                
-                yield ChatResponse(
-                    content=content,
-                    tool_calls=tool_calls,
-                    done=True
-                )
+
+                yield ChatResponse(content=content, tool_calls=tool_calls, done=True)
             else:
-                # Streaming: yield chunks
                 with self._client.stream("POST", url, json=payload) as resp:
                     resp.raise_for_status()
-                    
-                    chunks = []
+
+                    chunks: list[str] = []
                     tool_calls = None
-                    
+
                     for line in resp.iter_lines():
                         if not line:
                             continue
-                        
                         try:
                             data = json.loads(line)
                         except json.JSONDecodeError:
                             continue
-                        
+
                         msg = data.get("message", {}) or {}
                         chunk = msg.get("content", "")
-                        
+
                         if chunk:
                             chunks.append(chunk)
                             yield ChatResponse(content=chunk, done=False)
-                        
+
                         if msg.get("tool_calls"):
                             tool_calls = msg["tool_calls"]
-                        
+
                         if data.get("done"):
                             self._log_performance(data)
                             yield ChatResponse(
@@ -145,31 +233,26 @@ class OllamaBackend(BaseBackend):
         except httpx.HTTPError as e:
             self.logger.error(f"Ollama request failed: {e}")
             raise
-    
+
     def _log_performance(self, data: dict):
-        """Log performance metrics if available."""
         if "eval_count" in data and "eval_duration" in data:
             tokens = data["eval_count"]
             duration_ns = data["eval_duration"]
             if duration_ns > 0:
                 tok_per_sec = tokens / (duration_ns / 1e9)
                 self.logger.info(f"⚡ {tokens} tokens @ {tok_per_sec:.1f} tok/s")
-    
+
     def is_available(self) -> bool:
-        """Check if Ollama is running."""
         try:
-            url = f"{self.settings.local_host}/api/tags"
-            resp = self._client.get(url, timeout=3)
+            resp = self._client.get(f"{self.settings.local_host}/api/tags", timeout=3)
             return resp.status_code == 200
         except Exception as e:
             self.logger.debug(f"Ollama unavailable: {e}")
             return False
-    
+
     def get_models(self) -> list[str]:
-        """List Ollama models."""
         try:
-            url = f"{self.settings.local_host}/api/tags"
-            resp = self._client.get(url, timeout=5)
+            resp = self._client.get(f"{self.settings.local_host}/api/tags", timeout=5)
             resp.raise_for_status()
             data = resp.json()
             return [m["name"] for m in data.get("models", [])]
@@ -180,95 +263,83 @@ class OllamaBackend(BaseBackend):
 
 class LlamaCppBackend(BaseBackend):
     """llama.cpp backend with OpenAI-compatible API."""
-    
+
     def __init__(self, settings: Settings):
         super().__init__(settings)
         self.server = None
         self._ensure_server()
-    
+
     def _ensure_server(self):
-        """Ensure llama.cpp server is running."""
         from .llamacpp_server import LlamaCppServer
-        
         self.server = LlamaCppServer(self.settings)
         if not self.server.is_running():
             self.logger.info("🚀 Starting llama.cpp server...")
             self.server.start()
-    
+
     def chat(self, messages: list[dict], model: str, tools: list[dict] = None,
              stream: bool = True) -> Iterator[ChatResponse]:
-        """Send chat to llama.cpp OpenAI API."""
         if not self.server or not self.server.is_running():
             self._ensure_server()
-        
+
         url = f"http://127.0.0.1:{self.settings.llamacpp_port}/v1/chat/completions"
-        
-        # Optimized payload
+
         payload = {
             "messages": messages,
             "stream": stream,
             "max_tokens": 2048,
-            "temperature": 0.05,  # Low = fast + deterministic
+            "temperature": 0.05,
             "top_p": 0.85,
             "frequency_penalty": 0.1,
             "presence_penalty": 0.1,
         }
-        
+
         if tools:
             payload["tools"] = tools
-        
-        self.logger.debug(f"llama.cpp: {len(messages)} messages, stream={stream}")
-        
+
         try:
             if not stream:
-                # Non-streaming
                 resp = self._client.post(url, json=payload)
                 resp.raise_for_status()
                 data = resp.json()
-                
                 choices = data.get("choices", [])
                 if choices:
                     message = choices[0].get("message", {})
                     yield ChatResponse(
-                        content=message.get("content", ""),
+                        content=message.get("content", "") or "",
                         tool_calls=message.get("tool_calls"),
                         done=True
                     )
             else:
-                # Streaming
                 with self._client.stream("POST", url, json=payload) as resp:
                     resp.raise_for_status()
-                    
-                    chunks = []
+                    chunks: list[str] = []
                     tool_calls = None
-                    
+
                     for line in resp.iter_lines():
                         if not line or not line.startswith("data: "):
                             continue
-                        
-                        line = line[6:]  # Remove "data: "
+                        line = line[6:]
                         if line == "[DONE]":
                             break
-                        
                         try:
                             data = json.loads(line)
                         except json.JSONDecodeError:
                             continue
-                        
+
                         choices = data.get("choices", [])
                         if not choices:
                             continue
-                        
+
                         delta = choices[0].get("delta", {})
-                        chunk = delta.get("content", "")
-                        
+                        chunk = delta.get("content") or ""
+
                         if chunk:
                             chunks.append(chunk)
                             yield ChatResponse(content=chunk, done=False)
-                        
+
                         if delta.get("tool_calls"):
                             tool_calls = delta["tool_calls"]
-                        
+
                         if choices[0].get("finish_reason") == "stop":
                             yield ChatResponse(
                                 content="".join(chunks),
@@ -279,19 +350,16 @@ class LlamaCppBackend(BaseBackend):
         except httpx.HTTPError as e:
             self.logger.error(f"llama.cpp request failed: {e}")
             raise
-    
+
     def is_available(self) -> bool:
-        """Check if llama.cpp server is running."""
         return self.server and self.server.is_running()
-    
+
     def get_models(self) -> list[str]:
-        """Get loaded model path."""
         if self.settings.llamacpp_model_path:
             return [self.settings.llamacpp_model_path]
         return []
-    
+
     def shutdown(self):
-        """Stop llama.cpp server."""
         if self.server:
             self.server.stop()
         self._cleanup()
@@ -300,13 +368,15 @@ class LlamaCppBackend(BaseBackend):
 def get_backend(settings: Settings) -> BaseBackend:
     """Factory function to get the appropriate backend."""
     backend_type = settings.backend.lower()
-    
-    if backend_type == "llamacpp":
+
+    if backend_type == "lmstudio":
+        return LMStudioBackend(settings)
+    elif backend_type == "llamacpp":
         return LlamaCppBackend(settings)
     elif backend_type == "ollama":
         return OllamaBackend(settings)
     else:
         raise ValueError(
             f"Unknown backend: '{backend_type}'.\n"
-            "Valid options: 'ollama' or 'llamacpp'"
+            "Valid options: 'lmstudio', 'ollama', or 'llamacpp'"
         )

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -20,65 +20,59 @@ class Settings:
     max_steps: int
     request_timeout_s: int
     dry_run: bool
-    
-    # Backend selection
-    backend: str = "ollama"  # "ollama" or "llamacpp"
-    
+
+    # Backend selection: "lmstudio", "ollama", or "llamacpp"
+    backend: str = "lmstudio"
+
+    # LM Studio settings
+    lmstudio_host: str = "http://localhost:1234"
+
     # llama.cpp specific settings
     llamacpp_model_path: str = "./models/phi-4-mini-Q4_K_M.gguf"
     llamacpp_port: int = 8080
     llamacpp_use_vulkan: bool = True
     llamacpp_n_gpu_layers: int = 32
     llamacpp_context_size: int = 4096
-    
+
     # Validation and error tracking
     _validation_errors: list[str] = field(default_factory=list, init=False, repr=False)
-    
+
     def __post_init__(self):
-        """Validate configuration after initialization."""
         self._validate_settings()
         if self._validation_errors:
             error_msg = "Configuration validation failed:\n" + "\n".join(f"  - {e}" for e in self._validation_errors)
             raise ValueError(error_msg)
-    
+
     def _validate_settings(self):
-        """Validate all settings and collect errors."""
-        # Validate URLs
         if not self.turbo_host.startswith(('http://', 'https://')):
             self._validation_errors.append(f"Invalid turbo_host URL: {self.turbo_host}")
         if not self.local_host.startswith(('http://', 'https://')):
             self._validation_errors.append(f"Invalid local_host URL: {self.local_host}")
-        
-        # Validate numeric values
+        if not self.lmstudio_host.startswith(('http://', 'https://')):
+            self._validation_errors.append(f"Invalid lmstudio_host URL: {self.lmstudio_host}")
+
         if self.max_steps <= 0:
             self._validation_errors.append(f"max_steps must be positive, got: {self.max_steps}")
         if self.request_timeout_s <= 0:
             self._validation_errors.append(f"request_timeout_s must be positive, got: {self.request_timeout_s}")
-        
-        # Validate required fields
         if not self.planner_model.strip():
             self._validation_errors.append("planner_model cannot be empty")
         if not self.coder_model.strip():
             self._validation_errors.append("coder_model cannot be empty")
-        
-        # Validate API key format (basic check)
         if self.api_key and len(self.api_key) < 10:
             self._validation_errors.append("api_key appears to be too short")
-        
-        # Validate backend
-        if self.backend.lower() not in ["ollama", "llamacpp"]:
-            self._validation_errors.append(f"backend must be 'ollama' or 'llamacpp', got: {self.backend}")
-        
-        # Validate llama.cpp settings
+
+        if self.backend.lower() not in ["lmstudio", "ollama", "llamacpp"]:
+            self._validation_errors.append(f"backend must be 'lmstudio', 'ollama', or 'llamacpp', got: {self.backend}")
+
         if self.llamacpp_port < 1 or self.llamacpp_port > 65535:
             self._validation_errors.append(f"llamacpp_port must be 1-65535, got: {self.llamacpp_port}")
         if self.llamacpp_n_gpu_layers < 0:
             self._validation_errors.append(f"llamacpp_n_gpu_layers must be >= 0, got: {self.llamacpp_n_gpu_layers}")
         if self.llamacpp_context_size < 512:
             self._validation_errors.append(f"llamacpp_context_size must be >= 512, got: {self.llamacpp_context_size}")
-    
+
     def with_overrides(self, **kwargs) -> 'Settings':
-        """Create a new Settings instance with specified overrides."""
         current_values = {
             'turbo_host': self.turbo_host,
             'local_host': self.local_host,
@@ -89,6 +83,7 @@ class Settings:
             'request_timeout_s': self.request_timeout_s,
             'dry_run': self.dry_run,
             'backend': self.backend,
+            'lmstudio_host': self.lmstudio_host,
             'llamacpp_model_path': self.llamacpp_model_path,
             'llamacpp_port': self.llamacpp_port,
             'llamacpp_use_vulkan': self.llamacpp_use_vulkan,
@@ -97,9 +92,8 @@ class Settings:
         }
         current_values.update({k: v for k, v in kwargs.items() if v is not None})
         return Settings(**current_values)
-    
+
     def to_dict(self) -> Dict[str, Any]:
-        """Convert settings to dictionary for logging/debugging."""
         return {
             'turbo_host': self.turbo_host,
             'local_host': self.local_host,
@@ -110,6 +104,7 @@ class Settings:
             'request_timeout_s': self.request_timeout_s,
             'dry_run': self.dry_run,
             'backend': self.backend,
+            'lmstudio_host': self.lmstudio_host,
             'llamacpp_model_path': self.llamacpp_model_path,
             'llamacpp_port': self.llamacpp_port,
             'llamacpp_use_vulkan': self.llamacpp_use_vulkan,
@@ -119,52 +114,43 @@ class Settings:
 
 
 def _strip_inline_comment(value: str) -> str:
-    """Remove inline comments from env values."""
-    # Find comment marker '#' and strip everything after it
     if '#' in value:
         value = value.split('#', 1)[0]
     return value.strip()
 
 
 def _load_env_file(env_path: Path) -> Dict[str, str]:
-    """Load environment variables from .env file with error handling."""
     env_vars = {}
     if not env_path.exists():
         return env_vars
-    
+
     try:
         content = env_path.read_text(encoding="utf-8")
         for line_num, line in enumerate(content.splitlines(), 1):
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
-            
             if "=" not in line:
                 logging.warning(f"Skipping malformed line {line_num} in {env_path}: {line}")
                 continue
-            
             key, val = line.split("=", 1)
             key = key.strip()
-            val = _strip_inline_comment(val)  # Strip inline comments
-            
+            val = _strip_inline_comment(val)
             if not key:
                 logging.warning(f"Empty key on line {line_num} in {env_path}")
                 continue
-            
             env_vars[key] = val
-            # Only set in os.environ if not already present
             os.environ.setdefault(key, val)
-        
+
         logging.info(f"Loaded {len(env_vars)} environment variables from {env_path}")
         return env_vars
-        
+
     except Exception as e:
         logging.error(f"Failed to load {env_path}: {e}")
         return env_vars
 
 
 def _parse_int_with_validation(value: str, name: str, min_value: int = 1) -> int:
-    """Parse integer with validation and helpful error messages."""
     try:
         parsed = int(value)
         if parsed < min_value:
@@ -177,39 +163,42 @@ def _parse_int_with_validation(value: str, name: str, min_value: int = 1) -> int
 
 
 def _parse_bool(value: str) -> bool:
-    """Parse boolean from string with multiple accepted formats."""
     return value.lower() in {"1", "true", "yes", "on", "enabled"}
 
 
 def load_settings(config_path: Optional[Path] = None) -> Settings:
-    """Load settings from environment and optional .env file with robust error handling."""
-    # Setup logging
+    """Load settings from environment and optional .env file."""
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
-    
-    # Load .env file
+
     env_path = config_path or Path(".env")
-    env_vars = _load_env_file(env_path)
-    
+    _load_env_file(env_path)
+
     try:
-        # Parse with validation
-        turbo_host = os.getenv("TURBO_HOST", "https://ollama.com")
+        # General
+        turbo_host = os.getenv("TURBO_HOST", "http://localhost:1234")  # fallback to LM Studio
         local_host = os.getenv("OLLAMA_LOCAL", "http://127.0.0.1:11434")
-        planner_model = os.getenv("PLANNER_MODEL", "deepseek-v3.1:671b")
-        coder_model = os.getenv("CODER_MODEL", "qwen2.5-coder:latest")
         api_key = os.getenv("OLLAMA_API_KEY", "")
-        
         max_steps = _parse_int_with_validation(os.getenv("MAX_STEPS", "25"), "MAX_STEPS")
         timeout = _parse_int_with_validation(os.getenv("REQUEST_TIMEOUT_S", "120"), "REQUEST_TIMEOUT_S")
         dry_run = _parse_bool(os.getenv("DRY_RUN", "0"))
-        
-        # Backend settings
-        backend = os.getenv("BACKEND", "ollama")
+
+        # Backend
+        backend = os.getenv("BACKEND", "lmstudio")
+
+        # Model selection — defaults to your Qwen3 stack
+        planner_model = os.getenv("PLANNER_MODEL", "qwen3-8b")
+        coder_model = os.getenv("CODER_MODEL", "qwen3-4b")
+
+        # LM Studio
+        lmstudio_host = os.getenv("LMSTUDIO_HOST", "http://localhost:1234")
+
+        # llama.cpp
         llamacpp_model_path = os.getenv("LLAMACPP_MODEL_PATH", "./models/phi-4-mini-Q4_K_M.gguf")
         llamacpp_port = _parse_int_with_validation(os.getenv("LLAMACPP_PORT", "8080"), "LLAMACPP_PORT", 1)
         llamacpp_use_vulkan = _parse_bool(os.getenv("LLAMACPP_USE_VULKAN", "1"))
         llamacpp_n_gpu_layers = _parse_int_with_validation(os.getenv("LLAMACPP_N_GPU_LAYERS", "32"), "LLAMACPP_N_GPU_LAYERS", 0)
         llamacpp_context_size = _parse_int_with_validation(os.getenv("LLAMACPP_CONTEXT_SIZE", "4096"), "LLAMACPP_CONTEXT_SIZE", 512)
-        
+
         settings = Settings(
             turbo_host=turbo_host,
             local_host=local_host,
@@ -220,23 +209,23 @@ def load_settings(config_path: Optional[Path] = None) -> Settings:
             request_timeout_s=timeout,
             dry_run=dry_run,
             backend=backend,
+            lmstudio_host=lmstudio_host,
             llamacpp_model_path=llamacpp_model_path,
             llamacpp_port=llamacpp_port,
             llamacpp_use_vulkan=llamacpp_use_vulkan,
             llamacpp_n_gpu_layers=llamacpp_n_gpu_layers,
             llamacpp_context_size=llamacpp_context_size,
         )
-        
+
         logging.info("Configuration loaded successfully")
         logging.debug(f"Configuration: {settings.to_dict()}")
         return settings
-        
+
     except Exception as e:
         raise ConfigurationError(f"Failed to load configuration: {e}") from e
 
 
 def compact_json(obj: object) -> str:
-    """Return compact JSON for logging."""
     try:
         return json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
     except (TypeError, ValueError) as e:
@@ -245,7 +234,6 @@ def compact_json(obj: object) -> str:
 
 
 def validate_configuration() -> bool:
-    """Validate current configuration and return True if valid."""
     try:
         load_settings()
         return True


### PR DESCRIPTION
## Summary
Adds full LM Studio backend support so the agent can run entirely locally via LM Studio's OpenAI-compatible API (`http://localhost:1234/v1`).

## Changes

### `agent/core/backend_manager.py`
- Added `LMStudioBackend` class — uses OpenAI-compatible streaming/non-streaming API (same format as llama.cpp but no server management needed since LM Studio handles it)
- Fixed `ChatResponse.tool_calls` type annotation: changed `list[dict] = None` → `Optional[list[dict]] = field(default=None)` (bug fix)
- `get_backend()` factory now supports `'lmstudio'` as a valid backend type

### `agent/core/config.py`
- Added `lmstudio_host` field to `Settings` (default: `http://localhost:1234`)
- Changed default `backend` from `'ollama'` → `'lmstudio'`
- Changed default `PLANNER_MODEL` from `deepseek-v3.1:671b` → `qwen3-8b`
- Changed default `CODER_MODEL` from `qwen2.5-coder:latest` → `qwen3-4b`
- Added `lmstudio` to the valid backend validation list
- `with_overrides()` and `to_dict()` updated to include `lmstudio_host`

### `.env.example` (new file)
- Full example config for LM Studio setup
- Comments showing all available Qwen3 model variants to swap in

## Usage after merge

1. Open LM Studio and load your model (e.g. `qwen3-8b`)
2. Start the local server in LM Studio (port 1234)
3. Copy `.env.example` → `.env`
4. Run:
```bash
python3 -m agent.core.orchestrator "your task here" --apply
```

## Model recommendations for your hardware (Ryzen 7 5825U, 32GB RAM, Vega 8)
| Role | Recommended Model | Speed |
|---|---|---|
| Planner | `qwen3-8b` | ~8-12 tok/s |
| Coder | `qwen3-4b` | ~15-20 tok/s |
| Fast dry-run | `qwen3-2b` or `qwen3-0.8b` | ~30+ tok/s |